### PR TITLE
Update to latest version of ZMQ4

### DIFF
--- a/src/lwt_zmq.ml
+++ b/src/lwt_zmq.ml
@@ -30,22 +30,22 @@ module Socket = struct
             | ZMQ.Socket.Poll_error -> assert false
           with
           (* Not ready *)
-          | ZMQ.ZMQ_exception (ZMQ.EAGAIN, _) -> raise Lwt_unix.Retry
+          | Unix.Unix_error (Unix.EAGAIN, _, _) -> raise Lwt_unix.Retry
           (* We were interrupted so we need to start all over again *)
-          | ZMQ.ZMQ_exception (ZMQ.EINTR, _) -> raise Break_event_loop
+          | Unix.Unix_error (Unix.EINTR, _, _) -> raise Break_event_loop
       )
     in
     let rec idle_loop () =
       try_lwt
         Lwt.wrap1 f s.socket
       with
-      | ZMQ.ZMQ_exception (ZMQ.EAGAIN, _) -> begin
+      | Unix.Unix_error ( Unix.EAGAIN, _, _) -> begin
         try_lwt
           io_loop ()
         with
         | Break_event_loop -> idle_loop ()
       end
-      | ZMQ.ZMQ_exception (ZMQ.EINTR, _) ->
+      | Unix.Unix_error (Unix.EINTR, _, _) -> 
           idle_loop ()
     in
     idle_loop ()

--- a/test/rep.ml
+++ b/test/rep.ml
@@ -1,5 +1,5 @@
 let () =
-  let z = ZMQ.init () in
+  let z = ZMQ.Context.create () in
   let socket = ZMQ.Socket.create z ZMQ.Socket.rep in
   ZMQ.Socket.bind socket "tcp://127.0.0.1:5555";
   Lwt_main.run (
@@ -12,6 +12,6 @@ let () =
     Lwt_io.printl "Reply sent"
   );
   ZMQ.Socket.close socket;
-  ZMQ.term z;
+  ZMQ.Context.terminate z;
   ()
 

--- a/test/req.ml
+++ b/test/req.ml
@@ -1,5 +1,5 @@
 let () =
-  let z = ZMQ.init () in
+  let z = ZMQ.Context.create () in
   let socket = ZMQ.Socket.create z ZMQ.Socket.req in
   ZMQ.Socket.connect socket "tcp://127.0.0.1:5555";
   Lwt_main.run (
@@ -12,6 +12,6 @@ let () =
     assert_lwt (reply = "reply")
   );
   ZMQ.Socket.close socket;
-  ZMQ.term z;
+  ZMQ.Context.terminate z;
   ()
 


### PR DESCRIPTION
EAGAIN and EINTR map to Unix.Unix_error.

Update init code in tests to use `Context` functions.
