### PR TITLE
Added Monitor Socket Support

### DIFF
--- a/src/lwt_zmq.ml
+++ b/src/lwt_zmq.ml
@@ -78,3 +78,9 @@ module Socket = struct
       send_all s (id :: message)
   end
 end
+
+module Monitor = struct
+
+  let recv s = Socket.wrap (fun s -> ZMQ.Monitor.recv ~block:false s) s
+
+end

--- a/src/lwt_zmq.mli
+++ b/src/lwt_zmq.mli
@@ -42,3 +42,10 @@ module Socket : sig
     val send : [ `Router ] t -> id_t -> string list -> unit Lwt.t
   end
 end
+
+module Monitor : sig
+
+  (** [recv socket] waits for a monitoring event on [socket] without blocking other
+      Lwt threads. *) 
+  val recv : [ `Monitor ] Socket.t -> ZMQ.Monitor.event Lwt.t
+end


### PR DESCRIPTION
Adding Monitor Socket Support for lwt-zmq. Wraps ZMQ.Monitor.recv to return ZMQ.Event.t values.